### PR TITLE
Cropufmf

### DIFF
--- a/deepnet/ReformatJson2COCO.py
+++ b/deepnet/ReformatJson2COCO.py
@@ -1,0 +1,239 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: transformer
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import json
+import numpy as np
+import os
+import cv2
+import csv
+
+# %%
+def ConvertJson2COCO(infile,outfile,newimdir=None,extrainfo=None,isma=False,imdir=None,skeledges=None,kpnames=None,catname='animal',
+                     behaviors=None,conditions=None,label_category_file=None):
+    with open(infile,'r') as f:
+        indata = json.load(f)
+    outdata = {}
+    if extrainfo is None:
+        extrainfo = {}
+    outdata['info'] = copy.deepcopy(extrainfo)
+    outdata['info']['movies'] = indata['movies']
+    outdata['annotations'] = []
+    outdata['images'] = []
+    if extrainfo is not None:
+        for k,v in extrainfo.items():
+            outdata['info'][k] = v
+    for i in range(len(indata['locdata'])):
+        x = indata['locdata'][i]
+        z = {}
+        z['id'] = i
+        if newimdir is not None:
+            filestr = os.path.split(x['img'][0])[-1]
+            z['file_name'] = os.path.join(newimdir,filestr)
+        else:
+            z['file_name'] = x['img'][0]
+        if isma:
+            assert imdir is not None, 'Must provide imdir for isma data'
+            imfile = os.path.join(imdir,z['file_name'])
+            assert os.path.exists(imfile), 'Image file does not exist: %s' % imfile
+            img = cv2.imread(imfile)
+            z['width'] = img.shape[1]
+            z['height'] = img.shape[0]
+        else:
+            z['width'] = x['roi'][2] # not sure how to make this more general
+            z['height'] = x['roi'][3]
+        outdata['images'].append(z)
+        y = {}
+        y['id'] = i
+        y['image_id'] = i # not sure how this will work when multi-animal
+        y['mov'] = x['imov']
+        y['frm'] = x['frm']
+        y['tgt'] = x['itgt']
+        y['bbox'] = [x['roi'][0]-1,x['roi'][1]-1,x['roi'][2],x['roi'][3]]
+        y['keypoints'] = []
+        nkpts = len(x['pabs'])//2
+        for j in range(nkpts):
+            y['keypoints'].append(x['pabs'][j]-1)
+            y['keypoints'].append(x['pabs'][nkpts+j]-1)
+            v = 2-int(x['occ'][j])
+            if np.isinf(x['pabs'][j]) or np.isnan(x['pabs'][j]) or \
+                np.isinf(x['pabs'][nkpts+j]) or np.isnan(x['pabs'][nkpts+j]):
+                    v = 0
+            y['keypoints'].append(v)
+        y['num_keypoints'] = nkpts
+        y['category_id'] = 0 # only one category
+        outdata['annotations'].append(y)
+
+    if label_category_file is not None:
+        # read in csv file
+        mft = [(x['mov'],x['frm'],x['tgt']) for x in outdata['annotations']]
+        with open(label_category_file,'r') as f:
+            csvreader = csv.DictReader(f)
+            for row in csvreader:
+                try:
+                    v = tuple([int(x) for x in [row['mov'],row['frm'],row['tgt']]])
+                    i = mft.index(v)
+                except ValueError:
+                    raise 'Could not find annotation for %s %s %s' % (row['mov'],row['frm'],row['tgt'])
+                    continue
+                outdata['annotations'][i]['behavior'] = int(row['behaviors'])
+                outdata['annotations'][i]['condition'] = int(row['conditions'])
+        if 'info' not in outdata:
+            outdata['info'] = {}
+        outdata['info']['behaviors'] = behaviors
+        outdata['info']['conditions'] = conditions
+
+    cat = {'id': 0, 'name': catname}
+    if skeledges is None:
+        skeledges = [[i,i+1] for i in range(nkpts-1)]
+    if kpnames is None:
+        kpnames = [f'kp{i}' for i in range(nkpts)]
+    cat['keypoints'] = kpnames
+    cat['skeleton'] = skeledges
+    outdata['categories'] = [cat,]
+
+    with open(outfile, 'w') as f:
+        json.dump(outdata, f)
+
+
+# %%
+# infile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20220525/multitarget_bubble_training_20210523_allGT_AR_params20210920/loc.json'
+# outfile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data/train_annotations.json'
+# newimdir = 'train'
+# ConvertJson2COCO(infile,outfile,newimdir)
+
+# infile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20220525/test/loc.json'
+# outfile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data/test_annotations.json'
+# newimdir = 'test'
+# ConvertJson2COCO(infile,outfile,newimdir)
+
+# %%
+# # cp -r /groups/branson/home/robiea/.apt/tpb4d19d6d_4b41_4a76_91d2_e37c6deaa229/multitarget_bubble_training_20210523_allGT_AR_params20210920 /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_train
+# # mkdir /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024
+# # cp -r /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_train/im /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/train
+extrainfo = {'description': 'Fly Bubble training data', 'version': 1.0, 'contributor': 'Alice A. Robie and Kristin Branson','date_created': '2024-10-24'}
+kpnames = [
+    'ant_head',
+    'right_eye',
+    'left_eye',
+    'left_thorax',
+    'right_thorax',
+    'pos_notum',
+    'pos_abdomen',
+    'right_mid_fe',
+    'right_mid_fetib',
+    'left_mid_fe',
+    'left_mid_fetib',
+    'right_front_tar',
+    'right_mid_tar',
+    'right_back_tar',
+    'left_back_tar',
+    'left_mid_tar',
+    'left_front_tar',
+    'right_mid_wing',
+    'right_outer_wing',
+    'left_mid_wing',
+    'left_outer_wing',
+]
+skeledges = [
+    [9,13],
+    [10,11],
+    [11,16],
+    [6,10],
+    [8,9],
+    [6,8],
+    [4,17],
+    [5,12],
+    [6,15],
+    [6,14],
+    [1,2],
+    [2,3],
+    [3,4],
+    [4,5],
+    [20,21],
+    [18,19],
+    [7,18],
+    [7,20],
+]
+
+infile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_train/loc.json'
+outfile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/train_annotations.json'
+newimdir = 'train'
+imdir = os.path.dirname(outfile)
+assert os.path.exists(imdir)
+extraargs = {'isma': False, 'imdir': imdir, 'skeledges': skeledges, 'kpnames': kpnames, 'catname': 'fly'}
+ConvertJson2COCO(infile,outfile,newimdir,extrainfo=extrainfo,**extraargs)
+
+# %%
+# # cp -r /groups/branson/home/robiea/.apt/tpfa9853c2_13f2_4007_aec1_7eeb2466c4e1/AddingWingsGTLabels/  /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_test
+# # cp -r /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_test/im /groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/test
+behaviors = {
+    1: 'moving',
+    2: 'grooming_or_standing',
+    3: 'close',
+    4: 'touching'
+}
+
+conditions = {
+    1: 'courtship',
+    2: 'female_aggression',
+    3: 'male_aggression',
+    4: 'non_social_lines',
+    5: 'different_genotype',
+    6: 'same_fly',
+    7: 'same_genotype'    
+}
+label_category_file = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/label_categories.csv'
+
+extrainfo['desription'] = 'Fly Bubble test data'
+infile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_test/loc.json'
+outfile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/test_annotations.json'
+newimdir = 'test'
+testargs = {'behaviors': behaviors, 'conditions': conditions, 'label_category_file': label_category_file}
+ConvertJson2COCO(infile,outfile,newimdir,extrainfo=extrainfo,**extraargs,**testargs)
+
+
+# %%
+infile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_interlabeler/loc.json'
+outfile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/test_inter_annotations.json'
+newimdir = 'test_interlabeler'
+ConvertJson2COCO(infile,outfile,newimdir,extrainfo=extrainfo,**extraargs)
+
+# %%
+infile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/cache_20241024_intralabeler/loc.json'
+outfile = '/groups/branson/home/bransonk/tracking/code/APT/data/FlyBubble/fly_bubble_data_20241024/test_intra_annotations.json'
+newimdir = 'test_intralabeler'
+ConvertJson2COCO(infile,outfile,newimdir,extrainfo=extrainfo,**extraargs)
+
+# %%
+extraargs
+
+# %%
+import matplotlib.pyplot as plt
+
+from pycocotools import coco
+train_data = coco.COCO(outfile)
+fig,ax = plt.subplots(3,3,figsize=(15,15))
+ax = ax.flatten()
+idx = np.random.choice(len(train_data.imgs),len(ax))
+for axi,i in enumerate(idx):
+    plt.sca(ax[axi])
+    print(train_data.anns[i])
+    print(train_data.imgs[i])
+    imfile = os.path.join(imdir,train_data.imgs[i]['file_name'])
+    plt.imshow(cv2.imread(imfile))
+    train_data.showAnns([train_data.anns[i],])
+    plt.gca().axis('image')

--- a/deepnet/crop_ufmf.py
+++ b/deepnet/crop_ufmf.py
@@ -52,8 +52,8 @@ def cropframe(frame,more,croprows,cropcols):
         x = region[0]
         y = region[1]
         data = region[2]
-        if x >= cropcols[1] or x + data.shape[1] <= cropcols[0] or \
-            y >= croprows[1] or y + data.shape[0] <= croprows[0]:
+        if x > cropcols[1] or x + data.shape[1] <= cropcols[0] or \
+            y > croprows[1] or y + data.shape[0] <= croprows[0]:
             continue
         cropdata = data.copy()
         cropx = x - cropcols[0]
@@ -61,13 +61,17 @@ def cropframe(frame,more,croprows,cropcols):
         if x < cropcols[0]:
             cropdata = cropdata[:,cropcols[0]-x:]
             cropx = 0
-        if x + data.shape[1] > cropcols[1]:
-            cropdata = cropdata[:,:-(x+data.shape[1]-cropcols[1])]
+        if x + data.shape[1] - 1 > cropcols[1]:
+            x1 = (x+data.shape[1])-cropcols[1] - 1
+            assert x1 > 0
+            cropdata = cropdata[:,:-x1]
         if y < croprows[0]:
             cropdata = cropdata[croprows[0]-y:,:]
             cropy = 0
-        if y + data.shape[0] > croprows[1]:
-            cropdata = cropdata[:-(y+data.shape[0]-croprows[1]),:]
+        if y + data.shape[0] - 1 > croprows[1]:
+            y1 = (y+data.shape[0]) - croprows[1] - 1
+            assert y1 > 0
+            cropdata = cropdata[:-y1,:]
         w = cropdata.shape[1]
         h = cropdata.shape[0]
         assert w > 0 and h > 0

--- a/deepnet/crop_ufmf.py
+++ b/deepnet/crop_ufmf.py
@@ -1,0 +1,354 @@
+from movies import Movie
+from ufmf import UfmfSaver
+import os
+import tqdm
+import argparse
+import ast
+import numpy as np
+
+ufmf_ver = 3
+
+def rotate_region(x,y,w,h,maxwidth,maxheight,rot90):
+    """
+    rotate_region(x,y,w,h,maxwidth,maxheight,rot90)
+    Rotate a region by rot90*90 degree counter-clockwise
+    x,y: top-left corner of the region
+    w,h: width and height of the region
+    maxwidth,maxheight: maximum width and height of the frame
+    rot90: number of 90 degree counter-clockwise rotations (0, 1, 2, or 3)
+    Notes:
+    Did this manually in my head, should probably check... 
+    Outputs:
+    x,y: top-left corner of the rotated region
+    w,h: width and height of the rotated region
+    """
+    rot90 = rot90 % 4
+    if rot90 == 0:
+        return x, y, w, h
+    elif rot90 == 1:
+        return y, maxwidth-x-w, h, w
+    elif rot90 == 2:
+        return maxwidth-x-h, maxheight-y-w, w, h
+    elif rot90 == 3:
+        return maxheight-y-h, x, h, w
+    else:
+        raise ValueError('rot90 must be 0, 1, 2, or 3')
+
+def cropframe(frame,more,croprows,cropcols):
+    """
+    cropframe(frame,more,croprows,cropcols)
+    Crop a frame represented with regions
+    frame: the frame, np.ndarray of size maxheight,maxwidth,...
+    more: regions in the frame, dict with key 'regions'
+    croprows: [startrow,endrow] to crop
+    cropcols: [startcol,endcol] to crop
+    Returns:
+    cfr: cropped frame
+    cropregions: cropped regions, list of [x,y,w,h,data] where x,y are top-left corner of the region,
+    w,h are width and height of the region, and data is the cropped region
+    """
+    cropregions = []
+    for region in more['regions']:
+        x = region[0]
+        y = region[1]
+        data = region[2]
+        if x >= cropcols[1] or x + data.shape[1] <= cropcols[0] or \
+            y >= croprows[1] or y + data.shape[0] <= croprows[0]:
+            continue
+        cropdata = data.copy()
+        cropx = x - cropcols[0]
+        cropy = y - croprows[0]
+        if x < cropcols[0]:
+            cropdata = cropdata[:,cropcols[0]-x:]
+            cropx = 0
+        if x + data.shape[1] > cropcols[1]:
+            cropdata = cropdata[:,:-(x+data.shape[1]-cropcols[1])]
+        if y < croprows[0]:
+            cropdata = cropdata[croprows[0]-y:,:]
+            cropy = 0
+        if y + data.shape[0] > croprows[1]:
+            cropdata = cropdata[:-(y+data.shape[0]-croprows[1]),:]
+        w = cropdata.shape[1]
+        h = cropdata.shape[0]
+        assert w > 0 and h > 0
+        cropregions.append([cropx,cropy,w,h,cropdata])
+    cfr = frame[croprows[0]:croprows[1]+1,cropcols[0]:cropcols[1]+1]
+    return cfr,cropregions
+
+def rotateframe(frame,regions,rot90=0):
+    """
+    rotateframe(frame,regions,rot90=0)
+    Rotate a frame and its regions by rot90*90 degree counter-clockwise
+    frame: the frame, np.ndarray of size maxheight,maxwidth,...
+    regions: regions in the frame, list of [x,y,w,h,data] where x,y are top-left corner of the region,
+    w,h are width and height of the region, and data is the region
+    rot90: integer, number of 90 degree counter-clockwise rotations
+    Returns:
+    rotframe: rotated frame
+    rotregions: rotated regions, list of [x,y,w,h,data] where x,y are top-left corner of the region,
+    w,h are width and height of the region, and data is the rotated region
+    """
+    assert isinstance(rot90,int)
+    rot90 = rot90 % 4
+    if rot90 == 0:
+        return frame,regions
+    rotregions = []
+    for region in regions:
+        x = region[0]
+        y = region[1]
+        w = region[2]
+        h = region[3]
+        data = region[4]
+        x,y,w,h = rotate_region(x,y,w,h,frame.shape[1],frame.shape[0],rot90)
+        rotdata = np.ascontiguousarray(np.rot90(data,rot90))
+        rotregions.append([x,y,w,h,rotdata])
+    rotframe = np.ascontiguousarray(np.rot90(frame,rot90))
+    return rotframe,rotregions
+
+def get_range_noutfiles(range):
+    """
+    get_range_noutfiles(range)
+    Get the number of output files for a range
+    range: None, [start,end], or [[start0,end0],[start1,end1],...]
+    Returns:
+    -1 if range is None
+    0 if range is [start,end]
+    len(range) if range is a list of ranges
+    """
+    if range is None:
+        return -1
+    if isinstance(range[0],int) and len(range) == 2:
+        return 0
+    return len(range)
+
+def cropufmf(inmoviefile,croprows=None,cropcols=None,cropframes=None,outmoviefiles=[],outdir=None,rot90=0):
+    """
+    cropufmf(inmoviefile,croprows=None,cropcols=None,cropframes=None,outmoviefiles=[],outdir=None,rot90=0)
+    Crop and rotate a UFMF movie
+    inmoviefile: input movie file
+    croprows: None, [start,end], or [[start0,end0],[start1,end1],...] to crop rows. Default: None
+    cropcols: None, [start,end], or [[start0,end0],[start1,end1],...] to crop columns. Default: None
+    cropframes: None, [start,end], or [[start0,end0],[start1,end1],...] to crop frames. Default: None
+    outmoviefiles: None or list of output movie files. If None or not enough, names will be autogenerated 
+    based on inmoviefile and cropping parameters: 
+    <outdir>/<inmoviefile>_crop_row<start0>to<end0>_col<start0>to<end0>_frame<start0>to<end0>_rot<rot90*90>.ufmf
+    outdir: None or default output directory
+    rot90: number of 90 degree counter-clockwise rotations
+    Returns:
+    list of output movie files
+    """
+
+    rot90 = rot90 % 4
+
+    # open input movie   
+    inmovieobj = Movie(inmoviefile)
+    inmovieobj.open()
+    nframes = inmovieobj.get_n_frames()
+    width = inmovieobj.get_width()
+    height = inmovieobj.get_height()
+    inufmfobj = inmovieobj.h_mov._ufmf
+    timestamps = inmovieobj.get_some_timestamps()
+    if outmoviefiles is None:
+        outmoviefiles = []
+
+    if (outdir is not None) and (not os.path.exists(outdir)):
+        os.makedirs(outdir)
+
+    # how many output files
+    ncroprows = get_range_noutfiles(croprows)
+    ncropcols = get_range_noutfiles(cropcols)
+    ncropframes = get_range_noutfiles(cropframes)
+    noutfiles = max([ncroprows,ncropcols,ncropframes])
+    if noutfiles == -1:
+        # no cropping specified, hopefully rot specified
+        pass
+    else:
+        if noutfiles == 0:
+            noutfiles = 1
+        if ncroprows == 0:
+            croprows = [croprows]*noutfiles
+        elif ncroprows > 0:
+            assert ncroprows == noutfiles, 'nout is not consistent for croprows'
+        if ncropcols == 0:
+            cropcols = [cropcols]*noutfiles
+        elif ncropcols > 0:
+            assert ncropcols == noutfiles, 'nout is not consistent for cropcols'
+        if ncropframes == 0:
+            cropframes = [cropframes]*noutfiles
+        elif ncropframes > 0:
+            assert ncropframes == noutfiles, 'nout is not consistent for cropframes'
+    
+    # set default values
+    if croprows is None:
+        croprows = [[0,-1]]*noutfiles
+    if cropcols is None:
+        cropcols = [[0,-1]]*noutfiles
+    if cropframes is None:
+        cropframes = [[0,-1]]*noutfiles
+
+    for i in range(noutfiles):
+        if croprows[i][1] < 0:
+            croprows[i][1] = height+croprows[i][1]
+        if cropcols[i][1] < 0:
+            cropcols[i][1] = width+cropcols[i][1]
+        if cropframes[i][1] < 0:
+            cropframes[i][1] = nframes+cropframes[i][1]
+            
+        assert croprows[i][0] >= 0 and croprows[i][1] < height and croprows[i][0] <= croprows[i][1], f'Invalid croprows {croprows[i]}'
+        assert cropcols[i][0] >= 0 and cropcols[i][1] < width and cropcols[i][0] <= cropcols[i][1], f'Invalid cropcols {cropcols[i]}'
+        assert cropframes[i][0] >= 0 and cropframes[i][1] < nframes and cropframes[i][0] <= cropframes[i][1], f'Invalid cropframes {cropframes[i]}'        
+
+    # default output directory is the same as the input directory
+    if outdir is None:
+        outdir = os.path.dirname(inmoviefile)
+
+    # default output file names
+    # split inmoviefile
+    _,fn = os.path.split(inmoviefile)
+    fnbase,ext = os.path.splitext(fn)
+        
+    # set output file names
+    outmoviefiles = [] + [None,]*(noutfiles-len(outmoviefiles))
+    for i in range(noutfiles):
+        if outmoviefiles[i] is not None:
+            continue
+        docroprows = croprows[i][0] > 0 or croprows[i][1] < height-1
+        docropcols = cropcols[i][0] > 0 or cropcols[i][1] < width-1
+        docropframes = cropframes[i][0] > 0 or cropframes[i][1] < nframes-1
+        dorotate = rot90 != 0
+        outfnbase = fnbase + '_crop'
+        if docroprows:
+            outfnbase += f'_row{croprows[i][0]}to{croprows[i][1]}'
+        if docropcols:
+            outfnbase += f'_col{cropcols[i][0]}to{cropcols[i][1]}'
+        if docropframes:
+            outfnbase += f'_frame{cropframes[i][0]}to{cropframes[i][1]}'        
+        if dorotate:
+            outfnbase += f'_rot{rot90*90}'
+        outmoviefile = os.path.join(outdir,outfnbase+ext)
+        outmoviefiles[i] = outmoviefile
+
+    # initialize output movie objects
+    outmovieobjs = []
+    for i in range(noutfiles):
+        outmoviefile = outmoviefiles[i]
+        print(f'Creating {outmoviefile}')
+        if rot90 % 2 == 0:
+            outwidth = cropcols[i][1]-cropcols[i][0]+1
+            outheight = croprows[i][1]-croprows[i][0]+1
+        else:
+            outwidth = croprows[i][1]-croprows[i][0]+1
+            outheight = cropcols[i][1]-cropcols[i][0]+1        
+        outmovieobj = UfmfSaver(outmoviefile, version=ufmf_ver, coding=inufmfobj.get_coding(),
+                                max_width=outwidth,max_height=outheight)
+        outmovieobjs.append(outmovieobj)
+
+    # add key frames
+    inufmfindex = inufmfobj.get_index()
+    keyframetype = 'mean'
+    nkeyframes = len(inufmfindex['keyframe'][keyframetype]['loc'])
+
+    # which keyframes to add
+    keyframe_timestamps = inufmfindex['keyframe'][keyframetype]['timestamp']
+    t0s = []
+    t1s = []
+    for i in range(noutfiles):
+        t1s.append(timestamps[cropframes[i][1]])
+        t0s.append(max([t for t in keyframe_timestamps if t <= cropframes[i][0]]))
+
+    for f in range(nkeyframes):
+        keyframe,timestamp = inufmfobj._get_keyframe_N(keyframetype,f)
+        for i in range(noutfiles):
+            if timestamp < t0s[i] or timestamp > t1s[i]:
+                continue
+            keyframe_crop = keyframe[croprows[i][0]:croprows[i][1]+1,cropcols[i][0]:cropcols[i][1]+1]
+            if rot90 != 0:
+                keyframe_crop = np.ascontiguousarray(np.rot90(keyframe_crop,rot90))
+            outmovieobjs[i].add_keyframe(keyframetype,keyframe_crop,timestamp)
+
+    # add frames
+    minframe = min([c[0] for c in cropframes])
+    maxframe = max([c[1] for c in cropframes])
+    for f in tqdm.trange(minframe,maxframe+1):
+        frame,timestamp,more = inmovieobj.h_mov.get_frame(f,_return_more=True)
+        for i in range(noutfiles):
+            if f < cropframes[i][0] or f > cropframes[i][1]:
+                continue
+            cfr,cropregions = cropframe(frame,more,croprows[i],cropcols[i])
+            if rot90 != 0:
+                cfr,cropregions = rotateframe(cfr,cropregions,rot90)
+            _ = outmovieobjs[i].add_frame(cfr,timestamp,cropregions,iscentered=False)
+
+
+    # close
+    for i in range(noutfiles):
+        print(f'Closing {outmoviefiles[i]}')
+        outmovieobjs[i].close()
+        
+    inmovieobj.close()
+    
+    return outmoviefiles
+    
+def validate_args(args):
+    """
+    validate_args(args)
+    Check that command line arguments are formatted properly. There will also be some additional checks
+    in the main function.
+    Checks that:
+    - inmoviefile exists
+    - croprows, cropcols, cropframes are a list of length 2 or a lists of lists of length 2
+    - croprows, cropcols, cropframes values are integers
+    Converts tuples to lists
+    """
+    if not os.path.exists(args.inmoviefile):
+        raise ValueError(f"Input file not found: {args.inmoviefile}")
+
+    def validate_crop_ranges(ranges, name):
+        if ranges is None:
+            return ranges
+        if isinstance(ranges, tuple):
+            ranges = list(ranges)
+        if not isinstance(ranges, list):
+            raise ValueError(f"{name} must be a list/tuple of tuples")
+        # single range will be universally applied
+        if isinstance(ranges[0], int) and len(ranges) == 2:
+            return ranges
+        for r in ranges:
+            if isinstance(r, tuple):
+                r = list(r)
+            if not isinstance(r, list) or len(r) != 2:
+                raise ValueError(f"Each {name} range must be a list of 2 integers")
+            for x in r:
+                if not isinstance(x, (int, np.integer)):
+                    raise ValueError(f"{name} range values must be integers")
+        return ranges
+
+    # Convert and validate
+    args.croprows = validate_crop_ranges(args.croprows, "croprows")
+    args.cropcols = validate_crop_ranges(args.cropcols, "cropcols")
+    args.cropframes = validate_crop_ranges(args.cropframes, "cropframes")
+        
+if __name__ == '__main__':
+    # parse args
+    parser = argparse.ArgumentParser(
+        description='Crop UFMF movie file',
+        epilog='Example: python crop_ufmf.py /path/to/inmoviefile.ufmf --croprows "[[0,100],[101,-1]]" --cropcols "[(0,200),(201,-1)]" --cropframes "[[200,300],[301,-1]]" --outmoviefiles /path/to/outfile1.ufmf /path/to/outfile2.ufmf --rot90 1'
+    )
+    parser.add_argument('inmoviefile', help='Input movie file')
+    parser.add_argument('--croprows', type=ast.literal_eval, help='Row crop ranges [[start0,end0], [start1,end1],...]')
+    parser.add_argument('--cropcols', type=ast.literal_eval, help='Column crop ranges [[start0,end0], [start1,end1],...]')
+    parser.add_argument('--cropframes', type=ast.literal_eval, help='Frame crop ranges [[start0,end0], [start1,end1],...]')
+    parser.add_argument('--outmoviefiles', nargs='+', help='Output movie filenames')
+    parser.add_argument('--outdir', default=None, help='Output directory')
+    parser.add_argument('--rot90', default=0, type=int, help='Number of counter-clockwise 90 degree rotations')
+
+    args = parser.parse_args()
+    
+    # print all args
+    for arg in vars(args):
+        print(f'{arg}: {getattr(args, arg)}')
+    
+    outmoviefiles = cropufmf(args.inmoviefile,croprows=args.croprows,cropcols=args.cropcols,cropframes=args.cropframes,
+                            outmoviefiles=args.outmoviefiles,outdir=args.outdir,rot90=args.rot90)
+    
+    print('Finished')

--- a/deepnet/crop_ufmf.py
+++ b/deepnet/crop_ufmf.py
@@ -254,7 +254,7 @@ def cropufmf(inmoviefile,croprows=None,cropcols=None,cropframes=None,outmoviefil
     t1s = []
     for i in range(noutfiles):
         t1s.append(timestamps[cropframes[i][1]])
-        t0s.append(max([t for t in keyframe_timestamps if t <= cropframes[i][0]]))
+        t0s.append(max([t for t in keyframe_timestamps if t <= timestamps[cropframes[i][0]]]))
 
     for f in range(nkeyframes):
         keyframe,timestamp = inufmfobj._get_keyframe_N(keyframetype,f)
@@ -287,7 +287,12 @@ def cropufmf(inmoviefile,croprows=None,cropcols=None,cropframes=None,outmoviefil
         
     inmovieobj.close()
     
-    return outmoviefiles
+    return {'outmoviefiles': outmoviefiles,
+            'croprows': croprows,
+            'cropcols': cropcols,
+            'cropframes': cropframes,
+            'rot90': rot90,
+            'outdir': outdir}
     
 def validate_args(args):
     """

--- a/deepnet/crop_ufmf.py
+++ b/deepnet/crop_ufmf.py
@@ -208,7 +208,7 @@ def cropufmf(inmoviefile,croprows=None,cropcols=None,cropframes=None,outmoviefil
     fnbase,ext = os.path.splitext(fn)
         
     # set output file names
-    outmoviefiles = [] + [None,]*(noutfiles-len(outmoviefiles))
+    outmoviefiles = outmoviefiles + [None,]*(noutfiles-len(outmoviefiles))
     for i in range(noutfiles):
         if outmoviefiles[i] is not None:
             continue

--- a/deepnet/test_crop_ufmf.py
+++ b/deepnet/test_crop_ufmf.py
@@ -53,10 +53,10 @@ testmovieobj.close()
 
 # %%
 # compare a frame
-f = 10050
+f = 150
 inmovieobj = Movie(inmoviefile)
 
-fig,ax = plt.subplots(3,len(outmoviefiles),figsize=(10*len(outmoviefiles),10),squeeze=False)
+fig,ax = plt.subplots(len(outmoviefiles),3,figsize=(30,10*len(outmoviefiles)),squeeze=False)
 print(ax.shape)
 inim,intimestamp = inmovieobj.get_frame(f)
 for i in range(len(outmoviefiles)):
@@ -76,17 +76,83 @@ for i in range(len(outmoviefiles)):
     testmovieobj = Movie(outmoviefiles[i])
     testmovieobj.open()
     im,timestamp = testmovieobj.get_frame(cf)
-    ax[0,i].imshow(cropinim,cmap='gray',vmin=0,vmax=255)
-    ax[0,i].set_title(f'in {intimestamp}')
-    ax[1,i].imshow(im,cmap='gray',vmin=0,vmax=255)
-    ax[1,i].set_title(f'out {timestamp}')
-    him = ax[2,i].imshow(cropinim-im)
-    ax[2,i].set_title('diff')
-    # show colorbar with ax[2,i]
-    plt.colorbar(him,ax=ax[2,i])
+    ax[i,0].imshow(cropinim,cmap='gray',vmin=0,vmax=255)
+    ax[i,0].set_title(f'in t = {intimestamp}')
+    ax[i,1].imshow(im,cmap='gray',vmin=0,vmax=255)
+    ax[i,1].set_title(f'out t = {timestamp}')
+    him = ax[i,2].imshow(np.abs(cropinim-im))
+    ax[i,2].set_title('absdiff, max = %f'%np.max(np.abs(cropinim-im)))
+    # show colorbar with ax[i,2]
+    plt.colorbar(him,ax=ax[i,2])
     testmovieobj.close()    
-
+fig.tight_layout()
 inmovieobj.close()
+
+# %%
+# for debugging what was going wrong on frame 150, column 1331
+
+if False:
+
+    i = 0
+    f = 150
+    inmovieobj = Movie(inmoviefile)
+    inmovieobj.open()
+    testmovieobj = Movie(outmoviefiles[i])
+    testmovieobj.open()
+
+    cf = f - cropframes[i][0]
+    r0 = croprows[i][0]
+    r1 = croprows[i][1]
+    if r1 < 0:
+        r1 = inim.shape[0] + r1
+    c0 = cropcols[i][0]
+    c1 = cropcols[i][1]
+    if c1 < 0:
+        c1 = inim.shape[1] + c1
+    inim,intimestamp,inmore = inmovieobj.h_mov.get_frame(f,_return_more=True)
+    cropinim = inim[r0:r1+1,c0:c1+1]
+    cropinim = np.rot90(cropinim,rot90)
+
+    im,timestamp,more = testmovieobj.h_mov.get_frame(cf,_return_more=True)
+    ad = np.abs(cropinim-im)
+    r,c = np.nonzero(ad)
+    for i in range(len(r)):
+        print(f'{r[i]},{c[i]}: in: {cropinim[r[i],c[i]]}, out: {im[r[i],c[i]]}, mean: {more["mean"][r[i],c[i]]}')
+
+    fig,ax = plt.subplots(1,1,figsize=(30,10))
+    plt.plot(cropinim[:,1331],'o',label='in')
+    plt.plot(r,cropinim[r,1331],'o',label='in diff')
+    #plt.plot(cropinim[1,:],label='in+1')
+    plt.plot(im[:,1331],'x',label='out')
+    plt.plot(r,im[r,1331],'x',label='out diff')
+    plt.legend()
+
+    testmovieobj.close()    
+    inmovieobj.close()
+
+    for region in inmore['regions']:
+        x0 = region[0]
+        y0 = region[1]
+        data = region[2]
+        x1 = x0 + data.shape[1]
+        y1 = y0 + data.shape[0]
+        if x0 <= 1331 and x1 >= 1331:
+            minerr = np.inf
+            for j in range(len(more['regions'])):
+                outx0 = more['regions'][j][0]
+                outy0 = more['regions'][j][1]
+                outx1 = outx0 + more['regions'][j][2].shape[1]
+                outy1 = outy0 + more['regions'][j][2].shape[0]
+                err = np.abs(x0-outx0) + np.abs(x1-outx1) + np.abs(y0-outy0) + np.abs(y1-outy1)
+                if err < minerr:
+                    minerr = err
+                    bestj = j
+                    bestx0 = outx0
+                    bestx1 = outx1
+                    besty0 = outy0
+                    besty1 = outy1
+            print(f'x = {x0},{x1}, y = {y0},{y1}')
+            print(f'closest to out region {bestj}: {bestx0},{bestx1}, {besty0},{besty1}')
 
 # %%
 inmoviefile = '/groups/branson/home/robiea/Projects_data/Labeler_APT/cx_GMR_SS00238_CsChr_RigC_20151007T150343/movie.ufmf'

--- a/deepnet/test_crop_ufmf.py
+++ b/deepnet/test_crop_ufmf.py
@@ -1,0 +1,90 @@
+# ---
+# jupyter:
+#   jupytext:
+#     cell_metadata_filter: -all
+#     custom_cell_magics: kql
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.11.2
+#   kernelspec:
+#     display_name: transformer
+#     language: python
+#     name: python3
+# ---
+
+# %%
+import crop_ufmf
+from movies import Movie
+import numpy as np
+# make matplotlib plot inline
+# %matplotlib inline
+# make matplotlib only show errors
+logging.getLogger('matplotlib').setLevel(logging.ERROR)
+import matplotlib.pyplot as plt
+# %load_ext autoreload
+# %autoreload 2
+
+
+# %%
+# set parameters
+inmoviefile = '/groups/branson/home/bransonk/tracking/code/APT/data/flyprism/fly_images/cam_0/image_cam_0_date_2024_12_20_time_16_05_44_v001.ufmf'
+outdir = '/groups/branson/home/bransonk/tracking/code/APT/data/flyprism/cropped/cam_0'
+cropcol = 1332
+croprows = [[0,-1],[0,-1]]
+cropcols = [[0,cropcol-1],[cropcol,-1]]
+cropframes = [[0,199],[100,299]]
+rot90 = 1
+# croprows = [[0,-1]]
+# cropcols = [[0,-1]]
+# cropframes = [[0,100]]
+
+# %%
+# main command
+outmoviefiles = crop_ufmf.cropufmf(inmoviefile,croprows=croprows,cropcols=cropcols,cropframes=cropframes,outdir=outdir,rot90=rot90)
+
+
+# %%
+# examine output ufmf index
+outmoviefile = outmoviefiles[0]
+testmovieobj = Movie(outmoviefile)
+testmovieobj.open()
+testindex = testmovieobj.h_mov._ufmf.get_index()
+print(testindex)
+testmovieobj.close()
+
+# %%
+# compare a frame
+f = 150
+inmovieobj = Movie(inmoviefile)
+
+fig,ax = plt.subplots(3,len(outmoviefiles),figsize=(10*len(outmoviefiles),10),squeeze=False)
+print(ax.shape)
+inim,intimestamp = inmovieobj.get_frame(f)
+for i in range(len(outmoviefiles)):
+    if f < cropframes[i][0] or f > cropframes[i][1]:
+        continue
+    cf = f - cropframes[i][0]
+    r0 = croprows[i][0]
+    r1 = croprows[i][1]
+    if r1 < 0:
+        r1 = inim.shape[0] + r1
+    c0 = cropcols[i][0]
+    c1 = cropcols[i][1]
+    if c1 < 0:
+        c1 = inim.shape[1] + c1
+    cropinim = inim[r0:r1+1,c0:c1+1]
+    cropinim = np.rot90(cropinim,rot90)
+    testmovieobj = Movie(outmoviefiles[i])
+    testmovieobj.open()
+    im,timestamp = testmovieobj.get_frame(cf)
+    ax[0,i].imshow(cropinim,cmap='gray',vmin=0,vmax=255)
+    ax[0,i].set_title(f'in {intimestamp}')
+    ax[1,i].imshow(im,cmap='gray',vmin=0,vmax=255)
+    ax[1,i].set_title(f'out {timestamp}')
+    ax[2,i].imshow(cropinim-im)
+    ax[2,i].set_title('diff')
+    testmovieobj.close()    
+
+inmovieobj.close()

--- a/deepnet/test_crop_ufmf.py
+++ b/deepnet/test_crop_ufmf.py
@@ -36,11 +36,7 @@ croprows = [[0,-1],[0,-1]]
 cropcols = [[0,cropcol-1],[cropcol,-1]]
 cropframes = [[0,199],[100,299]]
 rot90 = 1
-# croprows = [[0,-1]]
-# cropcols = [[0,-1]]
-# cropframes = [[0,100]]
 
-# %%
 # main command
 outmoviefiles = crop_ufmf.cropufmf(inmoviefile,croprows=croprows,cropcols=cropcols,cropframes=cropframes,outdir=outdir,rot90=rot90)
 
@@ -88,3 +84,10 @@ for i in range(len(outmoviefiles)):
     testmovieobj.close()    
 
 inmovieobj.close()
+
+# %%
+inmoviefile = '/groups/branson/home/robiea/Projects_data/Labeler_APT/cx_GMR_SS00238_CsChr_RigC_20151007T150343/movie.ufmf'
+cropframes = [10000,19999]
+outmoviefiles = ['cx_GMR_SS00238_CsChr_RigC_20151007T150343_cropframes10000to19999.ufmf',]
+crop_ufmf.cropufmf(inmoviefile,cropframes=cropframes,outmoviefiles=outmoviefiles)
+

--- a/deepnet/test_crop_ufmf.py
+++ b/deepnet/test_crop_ufmf.py
@@ -38,7 +38,8 @@ cropframes = [[0,199],[100,299]]
 rot90 = 1
 
 # main command
-outmoviefiles = crop_ufmf.cropufmf(inmoviefile,croprows=croprows,cropcols=cropcols,cropframes=cropframes,outdir=outdir,rot90=rot90)
+res = crop_ufmf.cropufmf(inmoviefile,croprows=croprows,cropcols=cropcols,cropframes=cropframes,outdir=outdir,rot90=rot90)
+outmoviefiles = res['outmoviefiles']
 
 
 # %%
@@ -52,7 +53,7 @@ testmovieobj.close()
 
 # %%
 # compare a frame
-f = 150
+f = 10050
 inmovieobj = Movie(inmoviefile)
 
 fig,ax = plt.subplots(3,len(outmoviefiles),figsize=(10*len(outmoviefiles),10),squeeze=False)
@@ -79,15 +80,23 @@ for i in range(len(outmoviefiles)):
     ax[0,i].set_title(f'in {intimestamp}')
     ax[1,i].imshow(im,cmap='gray',vmin=0,vmax=255)
     ax[1,i].set_title(f'out {timestamp}')
-    ax[2,i].imshow(cropinim-im)
+    him = ax[2,i].imshow(cropinim-im)
     ax[2,i].set_title('diff')
+    # show colorbar with ax[2,i]
+    plt.colorbar(him,ax=ax[2,i])
     testmovieobj.close()    
 
 inmovieobj.close()
 
 # %%
 inmoviefile = '/groups/branson/home/robiea/Projects_data/Labeler_APT/cx_GMR_SS00238_CsChr_RigC_20151007T150343/movie.ufmf'
-cropframes = [10000,19999]
+cropframes = [10000,10099]
 outmoviefiles = ['cx_GMR_SS00238_CsChr_RigC_20151007T150343_cropframes10000to19999.ufmf',]
-crop_ufmf.cropufmf(inmoviefile,cropframes=cropframes,outmoviefiles=outmoviefiles)
+res = crop_ufmf.cropufmf(inmoviefile,cropframes=cropframes,outmoviefiles=outmoviefiles)
+outmoviefiles = res['outmoviefiles']
+croprows = res['croprows']
+cropcols = res['cropcols']
+cropframes = res['cropframes']
+outdir = res['outdir']
+rot90 = res['rot90']
 

--- a/external/JAABA/filehandling/plot2svg.m
+++ b/external/JAABA/filehandling/plot2svg.m
@@ -104,7 +104,7 @@ if exist('OCTAVE_VERSION','builtin')
     PLOT2SVG_globals.octave = true;
     disp('   Info: PLOT2SVG runs in Octave mode.')
 else
-    if str2num(matversion(1))<6 % Check for matlab version and print warning if matlab version lower than version 6.0 (R.12)
+    if str2double(matversion(1))<6 % Check for matlab version and print warning if matlab version lower than version 6.0 (R.12)
         disp('   Warning: Future versions may no more support older versions than MATLAB R12.')
     end
 end
@@ -2380,7 +2380,7 @@ if strcmp(get(ax,'XTickLabelMode'),'auto') && strcmp(get(ax,'XScale'),'linear')
     fontsize=convertunit(get(ax,'FontSize'),get(ax,'FontUnits'),'points');   % convert fontsize to inches
     font_color=searchcolor(ax,get(ax,'XColor'));
     if PLOT2SVG_globals.octave
-        % Octave stores XTickLabel in a cell array, which does not work nicely with str2num. --Jakob Malm
+        % Octave stores XTickLabel in a cell array, which does not work nicely with str2double. --Jakob Malm
         axlabelx = get(ax, 'XTickLabel');
         numlabels = zeros(length(axlabelx), 1);
         for ix = 1:length (axlabelx)
@@ -2405,14 +2405,14 @@ if strcmp(get(ax,'YTickLabelMode'),'auto') && strcmp(get(ax,'YScale'),'linear')
     fontsize=convertunit(get(ax,'FontSize'),get(ax,'FontUnits'),'points');
     font_color=searchcolor(ax,get(ax,'YColor'));
     if PLOT2SVG_globals.octave
-        % Octave stores YTickLabel in a cell array, which does not work nicely with str2num. --Jakob Malm
+        % Octave stores YTickLabel in a cell array, which does not work nicely with str2double. --Jakob Malm
         axlabely = get(ax, 'YTickLabel');
         numlabels = zeros(length(axlabely), 1);
         for ix = 1:length(axlabely)
-            numlabels(ix) = str2num(axlabely{ix});
+            numlabels(ix) = str2double(axlabely{ix});
         end        
     else
-        numlabels = str2num(get(ax,'YTickLabel'));
+        numlabels = str2double(get(ax,'YTickLabel'));
     end
     labelpos = get(ax,'YTick');
     numlabels = numlabels(:);
@@ -2429,26 +2429,28 @@ end
 if strcmp(get(ax,'ZTickLabelMode'),'auto') && strcmp(get(ax,'ZScale'),'linear')
     fontsize=convertunit(get(ax,'FontSize'),get(ax,'FontUnits'),'points');
     font_color=searchcolor(ax,get(ax,'ZColor'));
-    if PLOT2SVG_globals.octave
-        % Octave stores ZTickLabel in a cell array, which does not work nicely with str2num. --Jakob Malm
-        axlabelz = get (ax, 'ZTickLabel');
+    axlabelz = get (ax, 'ZTickLabel');
+    if ~isempty(axlabelz),
+      if PLOT2SVG_globals.octave
+        % Octave stores ZTickLabel in a cell array, which does not work nicely with str2double. --Jakob Malm
         numlabels = zeros(length(axlabelz), 1);
         for ix = 1:length(axlabelz)
-            numlabels(ix) = str2num(axlabelz{ix});
+          numlabels(ix) = str2double(axlabelz{ix});
         end
-    else
-        numlabels = str2num(get(ax,'ZTickLabel'));
-    end
-    labelpos = get(ax,'ZTick');
-    numlabels = numlabels(:);
-    labelpos = labelpos(:);
-    indexnz = find(labelpos ~= 0);
-    if (~isempty(indexnz) && ~isempty(numlabels))
+      else
+        numlabels = str2double(axlabelz);
+      end
+      labelpos = get(ax,'ZTick');
+      numlabels = numlabels(:);
+      labelpos = labelpos(:);
+      indexnz = find(labelpos ~= 0);
+      if (~isempty(indexnz) && ~isempty(numlabels))
         ratio = numlabels(indexnz)./labelpos(indexnz);
         if round(log10(ratio(1))) ~= 0
-            exptext = sprintf('&#215; 10<tspan font-size="%0.1fpt" dy="%0.1fpt">%g</tspan>',0.7*fontsize,-0.7*fontsize,-log10(ratio(1)));
-            label2svg(fid,group,axpos,ax,axpos(1)*paperpos(3),(1-(axpos(2)+axpos(4)))*paperpos(4)-0.5*fontsize,exptext,'left',0,'top',1,paperpos,font_color,0)           
+          exptext = sprintf('&#215; 10<tspan font-size="%0.1fpt" dy="%0.1fpt">%g</tspan>',0.7*fontsize,-0.7*fontsize,-log10(ratio(1)));
+          label2svg(fid,group,axpos,ax,axpos(1)*paperpos(3),(1-(axpos(2)+axpos(4)))*paperpos(4)-0.5*fontsize,exptext,'left',0,'top',1,paperpos,font_color,0)
         end
+      end
     end
 end
 

--- a/external/JAABA/filehandling/ufmf_read_header.m
+++ b/external/JAABA/filehandling/ufmf_read_header.m
@@ -111,6 +111,7 @@ end
 
 % read in the number of fields: 1
 nkeys = fread(fp,1,'uchar');
+index = struct;
 
 for j = 1:nkeys,
   

--- a/matlab/Labeler.m
+++ b/matlab/Labeler.m
@@ -3464,7 +3464,7 @@ classdef Labeler < handle
           continue;
         end
         for j = 1:numel(tObj.trnLastDMC.n),
-          nettype = tObj.trnLastDMC.getType(j);
+          nettype = tObj.trnLastDMC.getNetType(j);
           nettype = char(nettype{1});
           netmode = tObj.trnLastDMC.getNetMode(j);
           netmode = char(netmode{1});
@@ -3473,8 +3473,8 @@ classdef Labeler < handle
           fprintf('Tracker %d: %s, view %d, stage %d, mode %s\n',i,nettype,tObj.trnLastDMC.getView(j),tObj.trnLastDMC.getStages(j),netmode);
           fprintf('  Trained %s for %d iterations on %d labels\n',trainid,tObj.trnLastDMC.getIterCurr(j),tObj.trnLastDMC.getNLabels(j));
           if fileinfo,
-            fprintf('  Train config file: %s\n',tObj.trnLastDMC.trainConfigLnx(j));
-            fprintf('  Current trained model: %s\n',tObj.trnLastDMC.trainCurrModelLnx(j));
+            fprintf('  Train config file: %s\n',tObj.trnLastDMC.trainConfigLnx{j});
+            fprintf('  Current trained model: %s\n',tObj.trnLastDMC.trainCurrModelLnx{j});
           end
         end
       end


### PR DESCRIPTION
@adamltaylor can you doublecheck and merge into main? 

From log:

    Added crop_ufmf.py to crop and rotate ufmf files. test_crop_ufmf.py is a a jupytext notebook to test this.
    Added ReformatJson2COCO.py which does minor reformatting on the json files output from APT so that they are
    compatible with pycocotools.
    
    Getting crop_ufmf.py to work required some changes to ufmf.py, mainly in the writing part, which should
    not be used by APT. The only thing that is used in reading that is different is that the version 3 header
    is specified with Q (for unsigned int64) rather than L (which stands for long and is platform dependent,
    either unsigned int32 or unsigned int64).
    ufmf writing changes were mainly for python 3 compatibility, and based on changes to ufmf in motmot repo.
