### PR TITLE
Soften improper-crop assertion and add crop-size diagnostics

### DIFF
--- a/deepnet/APT_interface.py
+++ b/deepnet/APT_interface.py
@@ -1840,7 +1840,17 @@ def create_ma_crops(conf, frame, cur_pts, info, occ, roi, extra_roi):
         y_top = max(y_top, 0)
         y_bottom = y_top + conf.imsz[0]
 
-        assert (y_top-1) <= round(y_min) and (y_bottom+1) >= round(y_max) and (x_left-1) <= round(x_min) and (x_right+1) >= round(x_max), 'Cropping for cluster is improper'
+        ok = ((y_top-1) <= round(y_min) and (y_bottom+1) >= round(y_max)
+              and (x_left-1) <= round(x_min) and (x_right+1) >= round(x_max))
+        if not ok:
+            logging.warning(
+                'Improper crop (roi not fully contained). '
+                'info=%s roi x=[%g,%g] y=[%g,%g] crop x=[%d,%d] y=[%d,%d] '
+                'imsz=%s multi_frame_sz=%s frame.shape=%s. '
+                'Labels outside crop will be dropped.',
+                info, x_min, x_max, y_min, y_max,
+                x_left, x_right, y_top, y_bottom,
+                conf.imsz, conf.multi_frame_sz, frame.shape)
         return x_left, y_top, x_right, y_bottom
 
     def roi2patch(roi_in, x_left, y_top):

--- a/matlab/GTSuggest.m
+++ b/matlab/GTSuggest.m
@@ -111,7 +111,7 @@ output = handles.output;
       handles.etMinDistTrainingFrames.Value = val;
     else
       val = 1000;
-      handles.etMinDistTrainingFrames.String = val;
+      handles.etMinDistTrainingFrames.Value = val;
     end
 
   end
@@ -154,7 +154,7 @@ output = handles.output;
     movSelObj = handles.btngrpMovies.SelectedObject;
     if movSelObj==handles.rbAllMovies
       s.movSet = MovieIndexSetVariable.AllGTMov;
-      s.movIdxs = s.movSet.getMovieIndices(handles.lObj);
+      s.movIdxs = s.movSet.getMovieIndices(handles.labeler);
 
     elseif movSelObj==handles.rbSelectedMovies
       s.movSet = MovieIndexSetVariable.SelMov;

--- a/matlab/Labeler.m
+++ b/matlab/Labeler.m
@@ -9657,6 +9657,7 @@ classdef Labeler < handle
 % 
     function crop_sz = get_ma_crop_sz(obj)
       % Get crop sz for MA
+      fprintf('Setting crop size for multi-animal project\n');
       sagg = TrnPack.aggregateLabelsAddRoi(obj,false,...
         obj.trackParams.ROOT.MultiAnimal.Detect.BBox,...
         obj.trackParams.ROOT.MultiAnimal.LossMask);
@@ -9682,6 +9683,10 @@ classdef Labeler < handle
             xmax = max(cur_roi(3,:));
             ymin = min(cur_roi(5,:));
             ymax = max(cur_roi(6,:));
+            if (xmax-xmin > maxx) || (ymax-ymin > maxy),
+              fprintf('movie: %d, frame %d, (%d,%d)\n',ndx,fr,round(xmax-xmin),round(ymax-ymin));
+            end
+
             maxx = max(maxx,xmax-xmin);
             maxy = max(maxy,ymax-ymin);
           end
@@ -9689,6 +9694,7 @@ classdef Labeler < handle
       end
       crop_sz = max(maxx,maxy);
       crop_sz = ceil(crop_sz/min_crop)*min_crop;
+      fprintf('Crop size set to %d\n',crop_sz);
     end
 
     function r = maEstimateTgtCropRad(obj,cropszfac)


### PR DESCRIPTION
## Summary
- `create_ma_crops`: convert the improper-crop assertion in `random_crop_around_roi` to a warning that logs `info`/roi/crop/`imsz`/`multi_frame_sz`/`frame.shape`, so training can proceed past oversized ROIs. Labels outside the chosen crop are already dropped by the existing `labels_within_mask` filter, so the crop output remains shape-safe.
- `Labeler.get_ma_crop_sz`: print the movie/frame for each cluster that inflates the crop size, so outlier labels driving an oversized crop can be traced back to the source in the GUI.
- `GTSuggest`: fix two small bugs — `handles.etMinDistTrainingFrames.String = val` -> `.Value = val`, and `handles.lObj` -> `handles.labeler`.