### PR TITLE
Fix -continue tracking and delink target count mismatch

### DIFF
--- a/deepnet/APT_track.py
+++ b/deepnet/APT_track.py
@@ -39,6 +39,9 @@ def parse_args(argv):
     parser.add_argument('-track_type',choices=['predict_link','only_predict','only_link','link_id'], default='predict_link', help='for multi-animal. Whether to link the predictions or not, or only link existing tracklets. "predict_link" both predicts and links, "only_predict" only predicts but does not link, "only_link" only links existing predictions. For only_link, trk files with raw unlinked predictions must be supplied using -predict_trk_files option. Default is "predict_link"')
     parser.add_argument('-predict_trk_files', help='Intermediate trk files storing pure tracklets. Required when using link_only track_type', default=None, type=int)
 
+    parser.add_argument('-continue', dest='continue_tracking', action='store_true',
+                        help='Continue tracking from existing .part file.')
+
     parser.add_argument('-conf_params',
                         help='conf params. These will override params from lbl file. If the model is a 2 stage tracker then this will override the params only for the first stage', default=None, nargs='*')
     parser.add_argument('-conf_params2',
@@ -192,11 +195,16 @@ def main(argv):
         argv.pop(tndx)
         argv.pop(tndx)
 
+    if args.continue_tracking:
+        tndx = argv.index('-continue')
+        argv.pop(tndx)
+
     # if usestrippedlbl:
     #     cmd = f'{config_file} '
     # else:
     #     cmd = ''
-    cmd = f'{config_file} -type {mtypes[ndx]} -cache {tdir} {pre_str} {extra} -name {tstamps_str[ndx]} track {extra_2}'
+    continue_str = ' -continue' if args.continue_tracking else ''
+    cmd = f'{config_file} -type {mtypes[ndx]} -cache {tdir} {pre_str} {extra} -name {tstamps_str[ndx]} track {extra_2}{continue_str}'
 
 
 ##

--- a/deepnet/TrkFile.py
+++ b/deepnet/TrkFile.py
@@ -1216,7 +1216,7 @@ class Tracklet:
 
     self.remove_tgts(tgts_rem)
 
-  def delink(self):
+  def delink(self, ntargets=None):
     """
     Delink tracklets by reassigning detections based on detection order rather than tracking.
     After delinking, each frame's detections are assigned to targets sequentially:
@@ -1226,31 +1226,39 @@ class Tracklet:
 
     This breaks the temporal consistency of tracking where the same animal
     is followed across frames.
+
+    :param ntargets: If provided, use this as the number of targets instead of
+      computing from the data. This ensures consistency across fields (e.g. pTrk
+      and pTrkTag) that may have different default values.
     """
 
     if self.ntargets == 0 or self.T == 0:
       return
 
-    # Step 1: Find maximum number of detections in any single frame
-    max_detections_per_frame = 0
+    if ntargets is None:
+      # Step 1: Find maximum number of detections in any single frame
+      max_detections_per_frame = 0
 
-    for frame_idx in range(self.T0, self.T1 + 1):
-      detections_in_frame = 0
+      for frame_idx in range(self.T0, self.T1 + 1):
+        detections_in_frame = 0
 
-      # Count valid detections in this frame
-      for itgt in range(self.ntargets):
-        if (self.startframes[itgt] <= frame_idx <= self.endframes[itgt]):
-          # Get the frame data for this target
-          local_frame_idx = frame_idx - self.startframes[itgt]
-          if self.data[itgt] is not None:
-            frame_data = self.data[itgt][..., local_frame_idx]
-            if not np.all(equals_nan(frame_data, self.defaultval)):
-              detections_in_frame += 1
+        # Count valid detections in this frame
+        for itgt in range(self.ntargets):
+          if (self.startframes[itgt] <= frame_idx <= self.endframes[itgt]):
+            # Get the frame data for this target
+            local_frame_idx = frame_idx - self.startframes[itgt]
+            if self.data[itgt] is not None:
+              frame_data = self.data[itgt][..., local_frame_idx]
+              if not np.all(equals_nan(frame_data, self.defaultval)):
+                detections_in_frame += 1
 
-      max_detections_per_frame = max(max_detections_per_frame, detections_in_frame)
+        max_detections_per_frame = max(max_detections_per_frame, detections_in_frame)
 
-    # Step 2: Create new tracklet structure with max_detections_per_frame targets
-    new_ntargets = max_detections_per_frame
+      new_ntargets = max_detections_per_frame
+    else:
+      new_ntargets = ntargets
+
+    # Step 2: Create new tracklet structure with new_ntargets targets
     if new_ntargets == 0:
       return
 
@@ -2372,16 +2380,17 @@ class Trk:
     assert self.issparse, 'Delink is only implemented for sparse tracklet format'
     assert self.pTrk is not None, 'No tracklet data to delink'
 
-    # Delink the main tracking data
+    # Delink the main tracking data first to determine ntargets
     self.pTrk.delink()
+    ntargets = self.pTrk.ntargets
 
-    # Delink all associated tracking fields (timestamps, tags, confidences, etc.)
+    # Delink all associated tracking fields, forcing same ntargets as pTrk
     for k in self.trkFields:
       if self.__dict__[k] is not None:
-        self.__dict__[k].delink()
+        self.__dict__[k].delink(ntargets=ntargets)
 
     # Update ntargets to match the delinked tracklet structure
-    self.ntargets = self.pTrk.ntargets
+    self.ntargets = ntargets
 
   def truncate(self,T0=None,T1=None,reset=False):
     """


### PR DESCRIPTION
- APT_track.py: add -continue flag and pass it to APT_interface's track subcommand
- TrkFile.py: fix Trk.delink() to pass ntargets from pTrk to all other fields (pTrkTag, pTrkConf, etc.), preventing target count mismatch when fields have different default values (e.g. pTrkTag defaultval=False counts fewer "valid" detections than pTrk defaultval=NaN)