### PR TITLE
Small fixes: projectHasTrx adoption and InfoTimelineModel Body-prop filter

### DIFF
--- a/matlab/APTParameters.m
+++ b/matlab/APTParameters.m
@@ -229,7 +229,7 @@ classdef APTParameters
           netsUsed = labelerObj.trackerNetsUsed;
         end
         if isempty(hasTrx),
-          hasTrx = labelerObj.hasTrx;
+          hasTrx = labelerObj.projectHasTrx;
         end
         if isempty(trackerIsDL),
           trackerIsDL = labelerObj.trackerIsDL;

--- a/matlab/AxesHighlightManager.m
+++ b/matlab/AxesHighlightManager.m
@@ -33,11 +33,10 @@ classdef AxesHighlightManager < handle
       assert(isa(hAxes,'matlab.graphics.axis.Axes'));
       assert(~isempty(hAxes));
       
-      % NOTE: Trx vs noTrx, Axes vs Panels
-      % Atm, hasTrx-ness is not encoded at the project level. (It probably
-      % should be). Ie, a project may have some movies with trx and some
-      % without. So, the highlight manager must know how to handle both
-      % with-trx hilighting and without-trx highlighting.
+      % NOTE: Trx vs noTrx, Axes vs Panels. A project may have some movies with
+      % trx and some without (at least before training/tracking occurs). So, the
+      % highlight manager must know how to handle both with-trx hilighting and
+      % without-trx highlighting.
       
       obj.hAxs = hAxes;
       

--- a/matlab/GTManager.m
+++ b/matlab/GTManager.m
@@ -121,7 +121,7 @@ set(hFig,'Visible','on');
 centerfig(handles.figure1,controller.mainFigure_);
 
 function columnnames = getTblFrameColumnNames(handles)
-if handles.labeler.hasTrx,
+if handles.labeler.projectHasTrx,
   columnnames = {'Frame','Target','Labeled','Error'};
 else
   columnnames = {'Frame','Has Labels','Error'};
@@ -173,15 +173,15 @@ else
   if ~doupdate || strcmpi(fn,'frm'),
     data(:,1) = num2cell(handles.tbl.frm(idx));
   end
-  if handles.labeler.hasTrx && (~doupdate || strcmpi(fn,'iTgt')),
+  if handles.labeler.projectHasTrx && (~doupdate || strcmpi(fn,'iTgt')),
     data(:,2) = num2cell(handles.tbl.iTgt(idx));
   end
   if ~doupdate || strcmp(fn,'hasLbl'),
-    col = double(handles.labeler.hasTrx) + 2;
+    col = double(handles.labeler.projectHasTrx) + 2;
     data(:,col) = num2cell(handles.hasLbl(idx));
   end
   if ~doupdate || strcmp(fn,'err'),
-    col = double(handles.labeler.hasTrx) + 3;    
+    col = double(handles.labeler.projectHasTrx) + 3;    
     if any(~isnan(handles.err)),
       data(:,col) = num2cell(handles.err(idx));
     else
@@ -347,7 +347,7 @@ if ~isequal(newrow,oldrow),
 end
 
 data = handles.tblFrame.Data;
-if lObj.hasTrx,
+if lObj.projectHasTrx,
   newrow = find(cell2mat(data(:,1))==frm & cell2mat(data(:,2))==iTgt);
 else
   newrow = find(cell2mat(data(:,1))==frm);
@@ -393,7 +393,7 @@ if isempty(handles.tblFrame.Data),
 
 end
 ft = double(cell2mat(handles.tblFrame.Data(ftrow,1)));
-if lObj.hasTrx,
+if lObj.projectHasTrx,
   ft = [ft,double(cell2mat(handles.tblFrame.Data(ftrow,2)))];
 end
 mov = handles.iMovUn(movrow);

--- a/matlab/InfoTimelineModel.m
+++ b/matlab/InfoTimelineModel.m
@@ -52,7 +52,7 @@ classdef InfoTimelineModel < handle
   end
 
   methods
-    function obj = InfoTimelineModel(hasTrx)
+    function obj = InfoTimelineModel()
       obj.selectOn_ = false;
       obj.selectOnStartFrm_ = [];
       obj.curprop_ = 1;
@@ -63,7 +63,7 @@ classdef InfoTimelineModel < handle
       obj.statThresh_ = [];
       obj.isStatThreshVisible_ = false;
       obj.trackerAuxiliaryProps_ = EmptyLandmarkFeatureArray();
-      obj.initializePropsEtc_(hasTrx);  % fires no events
+      obj.initializePropsEtc_(false, false);  % fires no events
     end
     
     function v = get.selectOn(obj)
@@ -163,7 +163,7 @@ classdef InfoTimelineModel < handle
       result = obj.tldata_;
     end
     
-    function initializePropsEtc_(obj, hasTrx)
+    function initializePropsEtc_(obj, hasMovie, hasTrx)
       % Set .props, .props_tracker from .TLPROPS, .TLPROPS_TRACKER
 
       % Read the TL props from the .yaml file
@@ -173,9 +173,13 @@ classdef InfoTimelineModel < handle
       props = ReadLandmarkFeatureFile(tlpropfile);      
 
       % remove body features if no body tracking
-      if ~isempty(hasTrx) && ~hasTrx ,
+      if hasMovie && ~hasTrx
         idxremove = strcmpi({props.coordsystem},'Body');
         props(idxremove) = [];
+      else
+        % ~hasMovie || hasTrx
+        % If there's no movie then none of this stuff should be touched anyway.
+        % If the movie has trx then we want to leave the body coords in there.
       end
       obj.props_ = props;      
       obj.props_tracker_ = cat(1,obj.trackerAuxiliaryProps_,obj.props);
@@ -252,7 +256,7 @@ classdef InfoTimelineModel < handle
       end
       obj.clearSelection(nframes) ;
       obj.custom_data_ = [];
-      obj.initializePropsEtc_(hasTrx) ;  % fires no events
+      obj.initializePropsEtc_(hasMovie, hasTrx) ;  % fires no events
       if obj.getCurPropTypeIsAllFrames()
         obj.curproptype_ = 1 ;
         obj.curprop_ = 1 ;

--- a/matlab/Labeler.m
+++ b/matlab/Labeler.m
@@ -874,7 +874,7 @@ classdef Labeler < handle
       obj.isInDebugMode = isInDebugMode ;
       obj.isInAwsDebugMode = isInAwsDebugMode ;
       obj.progressMeter_ = ProgressMeter(obj) ;
-      obj.infoTimelineModel_ = InfoTimelineModel(obj.hasTrx);
+      obj.infoTimelineModel_ = InfoTimelineModel();
       obj.movieManagerModel_ = MovieManagerModel() ;
       obj.uncertainFramesModel_ = UncertainFramesModel(obj) ;
       % Set obj.isInInteractiveMode_ based on isInInteractiveModeRaw and

--- a/matlab/Labeler.m
+++ b/matlab/Labeler.m
@@ -11372,7 +11372,7 @@ classdef Labeler < handle
         error('Number of channels differs across views.');
       end
       s.cfg.NumChans = nchan; % see below, we change this again
-      s.cfg.HasTrx = obj.hasTrx;
+      s.cfg.HasTrx = obj.projectHasTrx;
 %       if nchan>1
 %         warningNoTrace('Images have %d channels. Typically grayscale images are preferred; select View>Convert to grayscale.',nchan);
 %       end

--- a/matlab/MovieManagerController.m
+++ b/matlab/MovieManagerController.m
@@ -465,7 +465,7 @@ classdef MovieManagerController < handle
       isMultiView = (lObj.nview > 1) ;
       movieColumnHeader = fif(isMultiView, 'Movieset', 'Movie') ;
       trxNames = mmModel.originalTrxNames ;
-      tfTrx = lObj.hasTrx && any(cellfun(@(x)~isempty(x), trxNames(:))) ;
+      tfTrx = lObj.projectHasTrx && any(cellfun(@(x)~isempty(x), trxNames(:))) ;
       if tfTrx
         args = {'ColumnName', {movieColumnHeader 'Trx' 'Num Labels'}, ...
                 'ColumnWidth', {'2x', '1x', 100}} ;

--- a/matlab/TrackBatchGUI.m
+++ b/matlab/TrackBatchGUI.m
@@ -146,7 +146,7 @@ classdef TrackBatchGUI < handle
       rowys = coltitley - (rowh+rowborder)*(1:obj.nmovies_per_page);
  
       macroedity = rowys(end) - 1.5*(rowh+rowborder);
-      hasTrx = obj.lObj.hasTrx;
+      hasTrx = obj.lObj.projectHasTrx;
       obj.hasTrx = hasTrx;
       if hasTrx
         macroedity(2) = macroedity - (rowh+rowborder);

--- a/matlab/TrackBatchGUI.m
+++ b/matlab/TrackBatchGUI.m
@@ -906,7 +906,7 @@ classdef TrackBatchGUI < handle
       partIndex = nviews + 1;
 
       % Handle trx files if project requires them
-      if obj.lObj.hasTrx
+      if obj.lObj.projectHasTrx
         if length(parts) >= partIndex + nviews - 1
           % Trx files specified for each view
           trxFiles = parts(partIndex:partIndex + nviews - 1);
@@ -1135,7 +1135,7 @@ classdef TrackBatchGUI < handle
         trk = obj.genTrkfile(movie,defaulttrk);
       end
       defaulttrx = obj.defaulttrxpat;
-      tfgentrx = obj.lObj.hasTrx && ~isempty(defaulttrx);
+      tfgentrx = obj.lObj.projectHasTrx && ~isempty(defaulttrx);
       if tfgentrx
         trx = obj.genTrkfile(movie,defaulttrx,'enforceExt',false);
       end

--- a/matlab/trackers/dt/DeepTracker.m
+++ b/matlab/trackers/dt/DeepTracker.m
@@ -1102,7 +1102,7 @@ classdef DeepTracker < LabelTracker
         
         sPrmAllLabeler = obj.lObj.trackGetTrainingParams();
         sPrmAllAsSet = obj.massageParamsIfNec(sPrmAllLabeler,'throwwarnings',false);
-        args = {'netsUsed',obj.getNetsUsed(),'hasTrx',obj.lObj.hasTrx,'trackerIsDL',true};
+        args = {'netsUsed',obj.getNetsUsed(),'hasTrx',obj.lObj.projectHasTrx,'trackerIsDL',true};
         
         if isempty(obj.sPrmAll),
           isParamChange = true;


### PR DESCRIPTION
## Summary
- Replace `labeler.hasTrx` with `labeler.projectHasTrx` at several call sites (APTParameters, GTManager, MovieManagerController, TrackBatchGUI, DeepTracker, Labeler save path) where the project-level notion is the right one.
- Tighten `InfoTimelineModel`'s Body-coordsystem filter: only strip Body props when a movie is loaded *and* has no trx, instead of stripping based on `hasTrx` alone (which dropped Body props when no movie was loaded yet). The constructor no longer takes `hasTrx`; `initializePropsEtc_` now takes `(hasMovie, hasTrx)`.
- Reword the stale comment in `AxesHighlightManager` about project-level hasTrx-ness.

## Test plan
- [ ] Open a project with trx and confirm GT Manager columns, MovieManager Trx column, TrackBatchGUI trx row, and parameter trees behave as before.
- [ ] Open a project without trx and confirm the same.
- [ ] Launch APT with no project loaded and confirm InfoTimeline Body-coordsystem props are still available.
- [ ] Run `test_apt()` for local-backend smoke coverage.