### PR TITLE
Make processed_dist symmetric

### DIFF
--- a/deepnet/link_trajectories.py
+++ b/deepnet/link_trajectories.py
@@ -3731,6 +3731,10 @@ def get_id_dist_mat(embed):
     processed_dist = pool.starmap(embed_dist, [(split_set[n], embed[:,None]) for n in range(n_threads)])
     processed_dist = merge_parallel(processed_dist)
     processed_dist =np.array(processed_dist)
+  # embed_dist is symmetric in exact arithmetic (mean of all cross-sample pairwise distances),
+  # but float32 rounding across the parallel row-blocks leaves a ~1e-6 asymmetry, which
+  # ssd.squareform (exact symmetry check, used by the no_motion/group_tracklets path) rejects.
+  processed_dist = (processed_dist + processed_dist.T) / 2.0
   return processed_dist
 
 def get_id_dist_mat_diag(embed):


### PR DESCRIPTION
`embed_dist` is symmetric in exact arithmetic (mean of all cross-sample pairwise distances), but float32 rounding across the parallel row-blocks leaves a ~1e-6 asymmetry, so squareform's tol=0 check raises "Distance matrix 'X' must be symmetric." and the mode crashes. 
Symmetrizing with `(D + D.T)/2` makes it robust to floating point differences.