### PR TITLE
Fix ufmf.py for modern numpy; stop reconfiguring root logger on import

### DIFF
--- a/deepnet/ufmf.py
+++ b/deepnet/ufmf.py
@@ -224,7 +224,7 @@ def _read_array(fd,buf_remaining):
     n_bytes, = struct.unpack('<L',n_bytes_buf)
 
     data_buf,buf_remaining = _read_min_chars(fd,n_bytes,buf_remaining)
-    larr = np.fromstring(data_buf,dtype=dtype_char)
+    larr = np.frombuffer(data_buf,dtype=dtype_char)
     return larr, buf_remaining
 
 def _read_dict(fd,buf_remaining=None):
@@ -471,13 +471,13 @@ class _UFmfV3LowLevelReader(object):
         if self._coding.lower() == 'rgb24':
             read_len = width*height*sz*self._bytesperpixel
             buf = self._fd_read(read_len)
-            frame = np.fromstring(buf,dtype=dtype)
+            frame = np.frombuffer(buf,dtype=dtype)
             frame.shape = (3,height,width)
             frame = frame.transpose((1,2,0))
         elif self._coding.lower() == 'mono8':
             read_len = width*height*sz
             buf = self._fd_read(read_len)
-            frame = np.fromstring(buf,dtype=dtype)
+            frame = np.frombuffer(buf,dtype=dtype)
             frame.shape = (height,width)
         else:
             raise NotImplementedError('Color coding %s not yet implemented'%self._coding)
@@ -505,13 +505,13 @@ class _UFmfV3LowLevelReader(object):
             if self._coding.lower() == 'rgb24':
                 lenbuf = w*h*self._bytesperpixel
                 buf = self._fd_read(lenbuf)
-                im = np.fromstring(buf,dtype=np.uint8)
+                im = np.frombuffer(buf,dtype=np.uint8)
                 im.shape = (self._bytesperpixel,h,w)
                 im = im.transpose((1,2,0))
             elif self._coding.lower() == 'mono8':
                 lenbuf = w*h
                 buf = self._fd_read(lenbuf)
-                im = np.fromstring(buf,dtype=np.uint8)
+                im = np.frombuffer(buf,dtype=np.uint8)
                 im.shape = (h,w)
             else:
                 raise NotImplementedError('Color coding %s not yet implemented'%self._coding)
@@ -567,13 +567,13 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
             # all pixel values.
             lenbuf = n_pts*self._points2_sz
             buf = self._fd_read(lenbuf)
-            locs = np.fromstring(buf,dtype=np.uint16)
+            locs = np.frombuffer(buf,dtype=np.uint16)
             locs.shape = (2,n_pts)
             # the pixel values are indexed by box number, followed by
             # column, followed by row, followed by color
             lenbuf = n_pts*self._w*self._h*self._bytesperpixel
             buf = self._fd_read(lenbuf)
-            im = np.fromstring(buf,dtype=np.uint8)
+            im = np.frombuffer(buf,dtype=np.uint8)
             im.shape = (self._bytesperpixel,self._h,self._w,n_pts)
             im = im.transpose(1,2,0,3)
             # if we need regions to be backwards compatible, we
@@ -596,13 +596,13 @@ class _UFmfV4LowLevelReader(_UFmfV3LowLevelReader):
                 if self._coding.lower() == 'rgb24':
                     lenbuf = w*h*self._bytesperpixel
                     buf = self._fd_read(lenbuf)
-                    im = np.fromstring(buf,dtype=np.uint8)
+                    im = np.frombuffer(buf,dtype=np.uint8)
                     im.shape = (self._bytesperpixel,h,w)
                     im = im.transpose((1,2,0))
                 elif self._coding.lower() == 'mono8':
                     lenbuf = w*h
                     buf = self._fd_read(lenbuf)
-                    im = np.fromstring(buf,dtype=np.uint8)
+                    im = np.frombuffer(buf,dtype=np.uint8)
                     im.shape = (h,w)
                 else:
                     raise NotImplementedError('Color coding %s not yet implemented'%self._coding)

--- a/deepnet/ufmf.py
+++ b/deepnet/ufmf.py
@@ -10,8 +10,6 @@ import numpy as np
 from numpy import nan
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
-
 import time
 
 import math


### PR DESCRIPTION
Two independent fixes to `deepnet/ufmf.py`, one commit each.

**Use `np.frombuffer` instead of `np.fromstring` (8 call sites).**
`np.fromstring()` on binary data has been deprecated since numpy 1.14 and is
removed in recent numpy, where it raises on binary input. `np.frombuffer()` is
the direct replacement and behaves identically here. Without this, reading .ufmf
movies fails outright on a current numpy.

**Don't call `logging.basicConfig(level=logging.DEBUG)` at import.**
Merely importing `ufmf` reconfigured the root logger to DEBUG for the entire
process, spamming any caller's logs. Configuring logging is the application's
job, not a library module's.

These were found while running the FlyDisco pipeline against a current numpy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)