### PR TITLE
Fix (some) Java-dependent GUI code broken on >=R2025a

### DIFF
--- a/matlab/WaitBarWithCancel.m
+++ b/matlab/WaitBarWithCancel.m
@@ -56,7 +56,7 @@ classdef WaitBarWithCancel < handle
   properties
     hWB % waitbar handle
     hTxt % handle to text obj in hWB
-    hBar % handle to hgjavacomponent graphical waitbar
+    hBar % handle to graphical bar in hWB (hgjavacomponent before R2025a, uiprogressindicator after)
     isCancel % scalar logical
     cancelData % optional data set on main thread by clients for passing info upstream
     
@@ -89,9 +89,14 @@ classdef WaitBarWithCancel < handle
       hText = findall(h,'type','text');
       hText.Interpreter = 'none';
       
+      hBar = findall(h,'type','hgjavacomponent');  % how waitbar draws the bar before R2025a
+      if isempty(hBar)
+        hBar = findall(h,'type','uiprogressindicator');  % how waitbar draws the bar from R2025a on
+      end
+
       obj.hWB = h;
       obj.hTxt = hText;
-      obj.hBar = findall(h,'type','hgjavacomponent');
+      obj.hBar = hBar;
       obj.isCancel = false;
     end
     
@@ -171,8 +176,9 @@ classdef WaitBarWithCancel < handle
     end
 
     function updateShowBar(obj)
+      % Show/hide the graphical bar per the top context's nobar setting.
       onoff = onIff(~isempty(obj.contexts) && ~obj.contexts(end).nobar);
-      obj.hBar.Visible = onoff;
+      set(obj.hBar, 'Visible', onoff);  % tolerates an empty obj.hBar
     end
   end
   

--- a/matlab/misc/imcontrast_kb.m
+++ b/matlab/misc/imcontrast_kb.m
@@ -139,6 +139,28 @@ iptwindowalign(figHandle, 'bottom', hHistFig, 'top');
 
 % Display figure and return
 set(hHistFig, 'visible', 'on');
+
+% On >=R2025a the OS window manager places a figure window when it is
+% first shown: the position set by the alignment above (while the figure
+% was invisible) is not honored, and the window can come up stacked
+% behind the target figure.  Raise the tool, then re-apply the alignment
+% until the position holds -- the window manager positions the window
+% asynchronously after it is first shown and can override a position
+% set too early.
+figure(hHistFig);
+previousPosition = [];
+for attempt = 1:10
+    iptwindowalign(figHandle, 'left', hHistFig, 'left');
+    iptwindowalign(figHandle, 'bottom', hHistFig, 'top');
+    drawnow;
+    pause(0.2);
+    currentPosition = get(hHistFig, 'OuterPosition');
+    if isequal(currentPosition, previousPosition)
+        break
+    end
+    previousPosition = currentPosition;
+end
+
 if nargout > 0
     hfigure = hHistFig;
 end

--- a/matlab/test/single-tests/test_adjust_contrast_tool_placement.m
+++ b/matlab/test/single-tests/test_adjust_contrast_tool_placement.m
@@ -1,0 +1,55 @@
+function test_adjust_contrast_tool_placement()
+% Test that the Adjust Contrast tool opens at its aligned position.
+%
+% imcontrast_kb() aligns the tool window to the target figure with
+% iptwindowalign() (left edges aligned, tool top at the target figure
+% bottom, clamped to stay onscreen).  On >=R2025a, figure windows are
+% placed by the OS window manager when first shown: a position set
+% while the figure is still invisible is not honored, so the tool
+% materialized wherever the window manager chose -- typically centered
+% over, and stacked behind, the main APT window.  The net effect was
+% that View > Adjust Brightness/Contrast... appeared to do nothing.
+%
+% The desired behavior is that after the menu actuation the tool
+% window already sits at its aligned position.  We check this by
+% re-running the alignment and asserting that the tool does not move.
+%
+% Note: this test is only meaningful in a MATLAB session with a real
+% display.  Without one, window placement is trivially honored and the
+% test passes even in the presence of the bug.
+
+% Start APT with an SA project (single view, so no view-picker dialog)
+linux_project_file_path = '/groups/branson/bransonlab/apt/unittest/pez7_al_updated_20241015.lbl' ;
+[projectFile, replace_path] = localize_test_project_path(linux_project_file_path) ;
+[labeler, controller] = StartAPT('projfile', projectFile, ...
+                                 'replace_path', replace_path, ...
+                                 'isInDebugMode', true, ...
+                                 'isInYodaMode', true) ;  %#ok<ASGLU>
+cleanupObj = onCleanup(@()(delete(controller))) ;
+drawnow() ;
+
+% Open the Adjust Contrast tool via the menu
+controller.controlActuated('menu_view_adjustbrightness') ;
+drawnow() ;
+pause(2) ;  % give the window manager time to place the window
+
+toolFigure = findall(groot(), 'Type', 'figure', 'Tag', 'imcontrast') ;
+assert(isscalar(toolFigure), 'Adjust Contrast tool figure not found') ;
+cleanupToolObj = onCleanup(@()(delete(toolFigure))) ;
+
+mainFigure = ancestor(controller.axes_curr, 'figure') ;
+positionBefore = get(toolFigure, 'OuterPosition') ;
+
+% Re-run the alignment that imcontrast_kb() is supposed to have
+% applied already.  If the tool is where it should be, this is a no-op.
+iptwindowalign(mainFigure, 'left', toolFigure, 'left') ;
+iptwindowalign(mainFigure, 'bottom', toolFigure, 'top') ;
+drawnow() ;
+pause(1) ;
+positionAfter = get(toolFigure, 'OuterPosition') ;
+
+offset = max(abs(positionAfter - positionBefore)) ;
+assert(offset < 50, ...
+       'Adjust Contrast tool was not at its aligned position: re-aligning moved it by %d pixels', ...
+       round(offset)) ;
+end  % function

--- a/matlab/test/single-tests/test_wait_bar_with_cancel.m
+++ b/matlab/test/single-tests/test_wait_bar_with_cancel.m
@@ -1,0 +1,47 @@
+function test_wait_bar_with_cancel()
+% Test that WaitBarWithCancel works through a full lifecycle of periods.
+% Guards against reliance on undocumented waitbar internals that changed in
+% R2025a, where the graphical bar is no longer an hgjavacomponent.
+
+wbObj = WaitBarWithCancel('Test title') ;
+cleanupObj = onCleanup(@()(delete(wbObj))) ;  %#ok<NASGU>
+
+% The handle to the graphical bar should be a valid scalar graphics object
+assert(isscalar(wbObj.hBar) && isvalid(wbObj.hBar), ...
+       'hBar is not a valid scalar handle') ;
+
+% A period showing the completed fraction as numerator/denominator
+wbObj.startPeriod('Doing stuff', 'shownumden', true, 'denominator', 10) ;
+isCancelRequested = wbObj.updateFracWithNumDen(3) ;
+assert(~isCancelRequested, 'Cancel should not have been requested') ;
+assert(strcmp(wbObj.hTxt.String, 'Doing stuff (3/10)'), ...
+       'Waitbar message is wrong: %s', wbObj.hTxt.String) ;
+wbObj.endPeriod() ;
+
+% A plain fractional period
+wbObj.startPeriod('More stuff') ;
+isCancelRequested = wbObj.updateFrac(0.5) ;
+assert(~isCancelRequested, 'Cancel should not have been requested') ;
+wbObj.endPeriod() ;
+
+% During a nobar period the graphical bar should be hidden, and it should
+% reappear when the enclosing period (which wants a bar) resumes
+wbObj.startPeriod('Outer stuff') ;
+wbObj.startPeriod('Quiet stuff', 'nobar', true) ;
+assert(strcmp(char(get(wbObj.hBar, 'Visible')), 'off'), ...
+       'Bar should be hidden during a nobar period') ;
+wbObj.endPeriod() ;
+assert(strcmp(char(get(wbObj.hBar, 'Visible')), 'on'), ...
+       'Bar should be shown again after the nobar period ends') ;
+wbObj.endPeriod() ;
+
+% Cancel-disabled construction should also work
+wbObj2 = WaitBarWithCancel('Test title 2', 'cancelDisabled', true) ;
+cleanupObj2 = onCleanup(@()(delete(wbObj2))) ;  %#ok<NASGU>
+wbObj2.startPeriod('Even more stuff') ;
+wbObj2.updateFrac(0.25) ;
+wbObj2.endPeriod() ;
+
+fprintf('test_wait_bar_with_cancel passed.\n') ;
+
+end  % function


### PR DESCRIPTION
R2025a removed Java from figure windows, and also made some UI
behavior changes, breaking two APT GUI bits.  Each fix follows the
failing-test-first convention.

## WaitBarWithCancel

`waitbar`'s graphical bar is no longer an `hgjavacomponent`, so
`obj.hBar` came up empty and `updateShowBar()` errored. Now we look
for the new `uiprogressindicator` as a fallback, and `updateShowBar()`
tolerates an empty handle. New test: `test_wait_bar_with_cancel.m`.

## Adjust Contrast tool

On >=R2025a the window manager places a figure asynchronously when
first shown, ignoring the position set while it was invisible — the
tool came up stacked behind the main window. `imcontrast_kb` now
raises the tool and re-applies the alignment until the position
sticks. New test: `test_adjust_contrast_tool_placement.m`.

## Heads up

cc @minnerbe in keeping with SciComp policy.
