### PR TITLE
Salvage uigetfilehelp fix from json_conf; retire the branch

### DIFF
--- a/external/JAABA/misc/uigetfilehelp.m
+++ b/external/JAABA/misc/uigetfilehelp.m
@@ -15,6 +15,6 @@ end
 varargout = cell(1,nargout);
 [varargout{:}] = uigetfile(inputs{:});
 
-if ~isnan(hhelp),
+if ishandle(hhelp),
   deletefileinfodialog(hhelp);
 end


### PR DESCRIPTION
## Summary

This PR closes out the long-abandoned **`json_conf`** branch by landing the
single change from it that is still useful and not yet on `main`: a one-line
MATLAB-compatibility fix in `external/JAABA/misc/uigetfilehelp.m`.

```diff
-if ~isnan(hhelp),
+if ishandle(hhelp),
```

`uigetfilehelp` initializes `hhelp` to `nan` and overwrites it with a graphics
handle when a help dialog is created. In modern MATLAB a handle is an object
rather than a plain double, so `isnan(hhelp)` no longer behaves correctly and
the cleanup guard can error. `ishandle()` returns `false` for `nan` and `true`
for a live handle, so it correctly covers both the "no dialog was created" and
"dialog was created" cases.

## Background: the `json_conf` branch

`json_conf` last saw activity in **March 2022** and `main` is ~2400 commits
ahead of its merge-base. It has two unmerged commits, and this PR intentionally
keeps only one small piece of them. Disposition of everything on the branch:

| Change on `json_conf` | State on current `main` | Action here |
|---|---|---|
| `uigetfilehelp.m`: `~isnan(hhelp)` → `ishandle(hhelp)` | Never applied (`main` still has `~isnan`) | **Included** (re-applied fresh) |
| `TrkFile.m`: add an `ntlts` property | Already evaluated and **explicitly rejected** — `main` carries `%ntlts  % Wasn't used anywhere` and a commented-out getter | Dropped |
| `available_cpu_count()` helper + two call sites in `link_trajectories.py` | Both call sites' multiprocessing pools are now dead/commented-out on `main`; the helper's intent was independently reintroduced elsewhere (see below) | Dropped |

After this PR merges, `json_conf` can be deleted with no loss.

## Out of scope: the `cpu_count()` / LSF issue

The branch's CPU commit was chasing a real bug: `multiprocessing.cpu_count()`
reports the **whole node**, not the CPUs the LSF scheduler allocated to the job.
We confirmed this empirically on the Janelia cluster with a 4-slot job on a
96-core node:

| Call | Result |
|---|---|
| `os.cpu_count()` | `96` (whole node — wrong) |
| `os.sched_getaffinity(0)` | `8` (respects the cpuset binding, but counts SMT threads) |
| `$LSB_DJOB_NUMPROC` | `4` (exact slot allocation) |

`main` already addresses the core insight independently: `deepnet/PoseTools.py`
sizes its preprocessing worker pool with `os.sched_getaffinity(0)` (added April
2026), which is a large improvement over `cpu_count()`. Two nuances remain,
which we consider **out of scope for this PR**:

1. `sched_getaffinity` over-counts by the hyperthreading factor (returned `8`
   for a 4-slot job); `$LSB_DJOB_NUMPROC` is the faithful allocation for sizing
   CPU-bound pools.
2. A couple of **live** `mp.cpu_count()` call sites remain on `main`
   (`deepnet/link_trajectories.py:3620`, `deepnet/script_idtracker_data.py:274`)
   that could adopt the same affinity/allocation-aware pattern.

Both are forward-looking cleanups on `main` in their own right, not part of
retiring `json_conf`, so they are deliberately left for a separate change.